### PR TITLE
Use timestamp from pcap pckthdr

### DIFF
--- a/include/cybermon/etsi_li.h
+++ b/include/cybermon/etsi_li.h
@@ -32,6 +32,7 @@ need to be called on the etsi_li object are connect and close.
 #include <string>
 #include <map>
 #include <queue>
+#include <sys/time.h>
 
 #include <boost/shared_ptr.hpp>
 
@@ -60,8 +61,8 @@ class sender {
   public:
 
     // Constructor.
-    sender() { 
-	
+    sender() {
+
 	cnx = false;
 
 	// 128kB buffer.
@@ -77,7 +78,7 @@ class sender {
 
     // Connect to host/port.
     void connect(const std::string& host, int port) {
-	
+
 	// Connect.
 	sock.connect(host, port);
 
@@ -90,7 +91,7 @@ class sender {
     void connect_tls(const std::string& host, int port,
 		     const std::string& keyfile, const std::string& certfile,
 		     const std::string& cafile) {
-	
+
 	// Connect.
 	sock.connect_tls(host, port, keyfile, certfile, cafile);
 
@@ -99,6 +100,7 @@ class sender {
     }
 
     static void encode_psheader(ber::berpdu& psheader_p,
+                                timeval tv,
 				const std::string& liid,
 				const std::string& oper,
 				uint32_t seq, uint32_t cin,
@@ -125,7 +127,7 @@ class sender {
 			       const std::string& net_element = "",
 			       const std::string& int_pt = "",
 			       const std::string& username = "");
-			       
+
     void ia_acct_start_response(const std::string& liid,
 				const tcpip::address& target_addr,
 				uint32_t seq, uint32_t cin,
@@ -135,7 +137,8 @@ class sender {
 				const std::string& int_pt = "",
 				const std::string& username = "");
 
-    void send_ip(const std::string& liid,
+    void send_ip(timeval tv,
+                 const std::string& liid,
 		 const std::string& oper,
 		 uint32_t seq, uint32_t cid,
 		 const std::vector<unsigned char>& packet,
@@ -193,7 +196,8 @@ class mux {
 			   const std::string& int_pt = "",
 			   const std::string& username = "");
 
-    void target_ip(const std::string& liid,
+    void target_ip(timeval tv,
+                   const std::string& liid,
 		   const std::vector<unsigned char>& pdu,
 		   const std::string& oper = "unknown",
 		   const std::string& country = "",
@@ -245,11 +249,11 @@ class receiver : public threads::thread {
 	running = true;
 	svr = s;
     }
-    
+
     virtual ~receiver() {}
     virtual void run();
     virtual void close_me(connection* c);
-    
+
 };
 
 };

--- a/src/capture.C
+++ b/src/capture.C
@@ -75,7 +75,8 @@ void pcap_dev::run()
 
 	    // Packet ready to go.
             // Time of packets from delay line will be 'now'
-	    deliv.receive_packet((struct timeval){0}, delay_line.front().packet, datalink);
+            timeval tv = {0};
+	    deliv.receive_packet(tv, delay_line.front().packet, datalink);
 	    delay_line.pop();
 
 

--- a/src/capture.C
+++ b/src/capture.C
@@ -6,7 +6,7 @@
 // FIXME: Thread this for performance.
 
 // Packet handler.
-void pcap_dev::handle(unsigned long len, unsigned long captured, 
+void pcap_dev::handle(timeval tv, unsigned long len, unsigned long captured,
 		      const unsigned char* payload)
 {
 
@@ -18,7 +18,7 @@ void pcap_dev::handle(unsigned long len, unsigned long captured,
 	packet.assign(payload, payload + captured);
 
 	// Submit to the delivery engine.
-	deliv.receive_packet(packet, datalink);
+	deliv.receive_packet(tv, packet, datalink);
 
     } else {
 
@@ -31,7 +31,7 @@ void pcap_dev::handle(unsigned long len, unsigned long captured,
 
 	// Set packet exit time.
 	timeradd(&now, &delay_val, &(delay_line.back().exit_time));
-    
+
 	// Put packet data on queue.
 	delay_line.back().packet.assign(payload, payload + captured);
 
@@ -74,7 +74,8 @@ void pcap_dev::run()
 		break;
 
 	    // Packet ready to go.
-	    deliv.receive_packet(delay_line.front().packet, datalink);
+            // Time of packets from delay line will be 'now'
+	    deliv.receive_packet((struct timeval){0}, delay_line.front().packet, datalink);
 	    delay_line.pop();
 
 

--- a/src/capture.h
+++ b/src/capture.h
@@ -12,8 +12,6 @@
 #include <cybermon/thread.h>
 #include <packet_consumer.h>
 
-#include <sys/time.h>
-
 #include <queue>
 
 class capture_dev : public threads::thread {
@@ -56,9 +54,9 @@ public:
     virtual void run();
 
     // Constructor.  i=interface name, d=packet consumer.
-    pcap_dev(const std::string& i, float delay, packet_consumer& d) : 
-	pcap_interface(i), deliv(d) { 
-	datalink = pcap_datalink(p); 
+    pcap_dev(const std::string& i, float delay, packet_consumer& d) :
+	pcap_interface(i), deliv(d) {
+	datalink = pcap_datalink(p);
 	this->delay = delay;
     }
 
@@ -66,7 +64,7 @@ public:
     virtual ~pcap_dev() {}
 
     // Packet handler.
-    virtual void handle(unsigned long len, unsigned long captured, 
+    virtual void handle(timeval tv, unsigned long len, unsigned long captured,
 			const unsigned char* bytes);
 
     virtual void stop() {

--- a/src/cybermon.C
+++ b/src/cybermon.C
@@ -56,12 +56,12 @@ public:
 		   const std::string& network,
 		   const tcpip::address& addr,
 		   const struct timeval& tv);
-    
+
     // Called when attacker is disconnected.
     void target_down(const std::string& liid,
 		     const std::string& network,
 		     const struct timeval& tv);
-    
+
 };
 
 // Called when attacker is discovered.
@@ -82,7 +82,7 @@ void etsi_monitor::target_down(const std::string& liid,
 }
 
 // Called when a PDU is received.
-void etsi_monitor::operator()(const std::string& liid, 
+void etsi_monitor::operator()(const std::string& liid,
 			      const std::string& network,
 			      const iter& s, const iter& e,
 			      const struct timeval& tv)
@@ -108,21 +108,21 @@ private:
     int count;
 
 public:
-    pcap_input(const std::string& f, cybermon::engine& e) : 
+    pcap_input(const std::string& f, cybermon::engine& e) :
 	pcap_reader(f), e(e) {
 	count = 0;
     }
 
-    virtual void handle(unsigned long len, unsigned long captured, 
+    virtual void handle(timeval tv, unsigned long len, unsigned long captured,
 			const unsigned char* f);
 
 };
 
 
-void pcap_input::handle(unsigned long len, unsigned long captured, 
+void pcap_input::handle(timeval tv, unsigned long len, unsigned long captured,
 			const unsigned char* f)
 {
-    
+
     int datalink = pcap_datalink(p);
 
     try {
@@ -134,15 +134,12 @@ void pcap_input::handle(unsigned long len, unsigned long captured,
 
 	    // IPv4 ethernet
 	    if (f[12] == 0x08 && f[13] == 0) {
-		
+
 		std::vector<unsigned char> v;
 		v.assign(f + 14, f + captured);
 
 		// FIXME: Hard-coded?!
 		std::string liid = "PCAP";
-
-		timeval tv;
-		gettimeofday(&tv, 0);
 
 		e.process(liid, "",
 			  cybermon::pdu_slice(v.begin(), v.end(), tv));
@@ -151,15 +148,12 @@ void pcap_input::handle(unsigned long len, unsigned long captured,
 
 	    // IPv6 ethernet only
 	    if (f[12] == 0x86 && f[13] == 0xdd) {
-		
+
 		std::vector<unsigned char> v;
 		v.assign(f + 14, f + captured);
 
 		// FIXME: Hard-coded?!
 		std::string liid = "PCAP";
-
-		timeval tv;
-		gettimeofday(&tv, 0);
 
 		e.process(liid, "",
 			  cybermon::pdu_slice(v.begin(), v.end(), tv));
@@ -171,15 +165,12 @@ void pcap_input::handle(unsigned long len, unsigned long captured,
 
 		// IPv4 ethernet
 		if (f[16] == 0x08 && f[17] == 0) {
-		
+
 		    std::vector<unsigned char> v;
 		    v.assign(f + 18, f + captured);
-		    
+
 		    // FIXME: Hard-coded?!
 		    std::string liid = "PCAP";
-
-		    timeval tv;
-		    gettimeofday(&tv, 0);
 
 		    e.process(liid, "",
 			      cybermon::pdu_slice(v.begin(), v.end(), tv));
@@ -188,15 +179,12 @@ void pcap_input::handle(unsigned long len, unsigned long captured,
 
 		// IPv6 ethernet only
 		if (f[16] == 0x86 && f[17] == 0xdd) {
-		
+
 		    std::vector<unsigned char> v;
 		    v.assign(f + 18, f + captured);
 
 		    // FIXME: Hard-coded?!
 		    std::string liid = "PCAP";
-
-		    timeval tv;
-		    gettimeofday(&tv, 0);
 
 		    e.process(liid, "",
 			      cybermon::pdu_slice(v.begin(), v.end(), tv));
@@ -216,9 +204,6 @@ void pcap_input::handle(unsigned long len, unsigned long captured,
 	    std::string liid = "PCAP";
 
 	    std::string str( v.begin(), v.end() );
-
-	    timeval tv;
-	    gettimeofday(&tv, 0);
 
 	    e.process(liid, "",
 		      cybermon::pdu_slice(v.begin(), v.end(), tv));
@@ -271,7 +256,7 @@ int main(int argc, char** argv)
 
 	if (pcap_file != "" && port != 0)
 	    throw std::runtime_error("Specify EITHER a PCAP file OR a port.");
-	    	    
+
 	if (pcap_file == "") {
 
 	    if (transport != "tls" && transport != "tcp")
@@ -302,7 +287,7 @@ int main(int argc, char** argv)
     }
 
     try {
-	
+
 	//queue to store the incoming packets to be processed
     std::queue<q_entry*>	cqueue;
 
@@ -330,7 +315,7 @@ int main(int argc, char** argv)
 	    sock->use_certificate_file(cert);
 	    sock->use_certificate_chain_file(chain);
 	    sock->check_private_key();
-	    
+
 	    // Create the monitor instance, receives ETSI events, and processes
 	    // data.
 	    etsi_monitor m(cqw);
@@ -340,10 +325,10 @@ int main(int argc, char** argv)
 	    r.start();
 
 	    // Wait forever.
-	    r.join();	    
+	    r.join();
 
 	} else {
-	
+
 	    // Create the monitor instance, receives ETSI events, and processes
 	    // data.
 		etsi_monitor m(cqw);
@@ -363,10 +348,10 @@ int main(int argc, char** argv)
 	cqr.join();
 
     } catch (std::exception& e) {
-	
+
 	std::cerr << "Exception: " << e.what() << std::endl;
 	return 1;
-	
+
     }
 
 }

--- a/src/delivery.h
+++ b/src/delivery.h
@@ -34,7 +34,7 @@ class ep {
 	this->params = params;
 	make_key();
     }
-	
+
     void make_key() {
 	std::ostringstream buf;
 	buf << hostname << ":" << port << ":" << type << ":" << transport;
@@ -73,7 +73,7 @@ class intf {
 
 	if (delay < i.delay)
 	    return true;
-	else 
+	else
 	    return false;
 
     }
@@ -90,7 +90,7 @@ class intf {
 
 class delivery : public parameters, public management, public packet_consumer {
   private:
-    
+
     // Lock for senders and targets maps.
     //threads::mutex lock;
 
@@ -145,7 +145,7 @@ class delivery : public parameters, public management, public packet_consumer {
     virtual void remove_interface(const std::string& iface,
 				  const std::string& filter,
 				  float delay);
-    
+
     // Returns the interfaces list.
     virtual void get_interfaces(std::list<interface_info>& ii);
 
@@ -173,7 +173,7 @@ class delivery : public parameters, public management, public packet_consumer {
     virtual ~delivery() {}
 
     // Allows caller to provide an IP packet for delivery.
-    virtual void receive_packet(const std::vector<unsigned char>& packet, 
+    virtual void receive_packet(timeval tv, const std::vector<unsigned char>& packet,
 				int datalink);
 
     // Modifies the target map to include a mapping from address to target.

--- a/src/etsi_li.C
+++ b/src/etsi_li.C
@@ -285,7 +285,8 @@ void sender::ia_acct_start_request(const std::string& liid,
 
     ber::berpdu psheader_p;
     // time for connection request will be taken as 'now'
-    encode_psheader(psheader_p, (struct timeval){0}, liid, oper, seq, cin, country, net_element,
+    timeval tv = {0};
+    encode_psheader(psheader_p, tv, liid, oper, seq, cin, country, net_element,
 		    int_pt);
 
     // ----------------------------------------------------------------------
@@ -366,7 +367,8 @@ void sender::ia_acct_start_response(const std::string& liid,
 
     ber::berpdu psheader_p;
     // time for connection response will be taken as 'now'
-    encode_psheader(psheader_p, (struct timeval){0}, liid, oper, seq, cin, country, net_element,
+    timeval tv = {0};
+    encode_psheader(psheader_p, tv, liid, oper, seq, cin, country, net_element,
 		    int_pt);
 
     // ----------------------------------------------------------------------
@@ -447,7 +449,8 @@ void sender::ia_acct_stop(const std::string& liid,
 
     ber::berpdu psheader_p;
     // time for disconnect will be taken as 'now'
-    encode_psheader(psheader_p, (struct timeval){0}, liid, oper, seq, cin, country, net_element,
+    timeval tv = {0};
+    encode_psheader(psheader_p, tv, liid, oper, seq, cin, country, net_element,
 		    int_pt);
 
     // ----------------------------------------------------------------------

--- a/src/etsi_li.C
+++ b/src/etsi_li.C
@@ -15,6 +15,7 @@ uint32_t mux::next_cin = 0;
 
 // Encodes the ETSI LI PS PDU PSHeader construct.
 void sender::encode_psheader(ber::berpdu& psheader_p,
+                             timeval tv,
 			     const std::string& liid,
 			     const std::string& oper,
 			     uint32_t seq, uint32_t cin,
@@ -26,20 +27,23 @@ void sender::encode_psheader(ber::berpdu& psheader_p,
     // Create a time string, GeneralizedTime.
     char tms[128];
     {
-	struct timeval now;
-	gettimeofday(&now, 0);
+        // If we've been passed no specific time then use 'now'
+        if (tv.tv_sec == 0) {
+	    gettimeofday(&tv, 0);
+        }
+
 	struct tm res;
-	struct tm* ts = gmtime_r(&now.tv_sec, &res);
+	struct tm* ts = gmtime_r(&tv.tv_sec, &res);
 	if (ts == 0)
 	    throw std::runtime_error("gmtime_r failed");
-	
-	// Convert time in seconds into into year, month... seconds. 
+
+	// Convert time in seconds into into year, month... seconds.
 	int ret = strftime(tms, 128, "%Y%m%d%H%M%S", ts);
 	if (ret < 0)
 	    throw std::runtime_error("Failed to format time string (strftime)");
 
 	// Append milliseconds and Z for GMT.
-	sprintf(tms + strlen(tms), ".%03dZ", int(now.tv_usec / 1000));
+	sprintf(tms + strlen(tms), ".%03dZ", int(tv.tv_usec / 1000));
 
     }
 
@@ -55,14 +59,14 @@ void sender::encode_psheader(ber::berpdu& psheader_p,
 
     // network element
     ber::berpdu netelt_p;
-    if (net_element != "") 
+    if (net_element != "")
 	netelt_p.encode_string(ber::context_specific, 1, net_element);
 
     // NetworkIdentifier
     ber::berpdu neid_p;
     pdus.clear();
     pdus.push_back(&operid_p);
-    if (net_element != "") 
+    if (net_element != "")
 	pdus.push_back(&netelt_p);
     neid_p.encode_construct(ber::context_specific, 0, pdus);
 
@@ -151,16 +155,16 @@ void sender::encode_ipiri(ber::berpdu& ipiri_p,
 
 	// Binary address
 	ber::berpdu binary_p;
-	binary_p.encode_string(ber::context_specific, 1, address->addr.begin(), 
+	binary_p.encode_string(ber::context_specific, 1, address->addr.begin(),
 			       address->addr.end());
-	
+
 	// IPtype
 	ber::berpdu iptype_p;
 	if (address->universe == address->ipv4)
 	    iptype_p.encode_int(ber::context_specific, 1, 0); // IPv4 = 0
 	else
 	    iptype_p.encode_int(ber::context_specific, 1, 1); // IPv6 = 1
-	
+
 	// IPvalue
 	ber::berpdu ipvalue_p;
 	pdus.clear();
@@ -174,7 +178,7 @@ void sender::encode_ipiri(ber::berpdu& ipiri_p,
 	ipaddress_p.encode_construct(ber::context_specific, 4, pdus);
 
     }
-	
+
     // ----------------------------------------------------------------------
     // Encode IPIRI
     // ----------------------------------------------------------------------
@@ -280,7 +284,8 @@ void sender::ia_acct_start_request(const std::string& liid,
     // ----------------------------------------------------------------------
 
     ber::berpdu psheader_p;
-    encode_psheader(psheader_p, liid, oper, seq, cin, country, net_element,
+    // time for connection request will be taken as 'now'
+    encode_psheader(psheader_p, (struct timeval){0}, liid, oper, seq, cin, country, net_element,
 		    int_pt);
 
     // ----------------------------------------------------------------------
@@ -360,7 +365,8 @@ void sender::ia_acct_start_response(const std::string& liid,
     // ----------------------------------------------------------------------
 
     ber::berpdu psheader_p;
-    encode_psheader(psheader_p, liid, oper, seq, cin, country, net_element,
+    // time for connection response will be taken as 'now'
+    encode_psheader(psheader_p, (struct timeval){0}, liid, oper, seq, cin, country, net_element,
 		    int_pt);
 
     // ----------------------------------------------------------------------
@@ -440,7 +446,8 @@ void sender::ia_acct_stop(const std::string& liid,
     // ----------------------------------------------------------------------
 
     ber::berpdu psheader_p;
-    encode_psheader(psheader_p, liid, oper, seq, cin, country, net_element,
+    // time for disconnect will be taken as 'now'
+    encode_psheader(psheader_p, (struct timeval){0}, liid, oper, seq, cin, country, net_element,
 		    int_pt);
 
     // ----------------------------------------------------------------------
@@ -460,7 +467,8 @@ void sender::ia_acct_stop(const std::string& liid,
 }
 
 // Transmit an IP packet
-void sender::send_ip(const std::string& liid,
+void sender::send_ip(timeval tv,
+                     const std::string& liid,
 		     const std::string& oper,
 		     uint32_t seq, uint32_t cin,
 		     const std::vector<unsigned char>& packet,
@@ -532,7 +540,7 @@ void sender::send_ip(const std::string& liid,
     // ----------------------------------------------------------------------
 
     ber::berpdu psheader_p;
-    encode_psheader(psheader_p, liid, oper, seq, cin, country, net_element,
+    encode_psheader(psheader_p, tv, liid, oper, seq, cin, country, net_element,
 		    int_pt);
 
     // ----------------------------------------------------------------------
@@ -567,13 +575,13 @@ void mux::target_connect(const std::string& liid,     // LIID
 
     cin[liid] = next_cin++;
 
-    // Describes connetion request.
+    // Describes connection request.
     transport.ia_acct_start_request(liid, iri_seq[liid]++, cin[liid], oper,
 				    country, net_elt, int_pt, username);
 
     // Describes connection response.
-    transport.ia_acct_start_response(liid, target_addr, iri_seq[liid]++, 
-				     cin[liid], oper, country, net_elt, 
+    transport.ia_acct_start_response(liid, target_addr, iri_seq[liid]++,
+				     cin[liid], oper, country, net_elt,
 				     int_pt, username);
 
 }
@@ -605,7 +613,8 @@ void mux::target_disconnect(const std::string& liid,     // LIID
 }
 
 // Called when a target IP packet is observed.
-void mux::target_ip(const std::string& liid,               // LIID
+void mux::target_ip(timeval tv,                            // Time of capture
+                    const std::string& liid,               // LIID
 		    const std::vector<unsigned char>& pdu, // Packet
 		    const std::string& oper,               // Operator ID
 		    const std::string& country,            // Country
@@ -623,7 +632,7 @@ void mux::target_ip(const std::string& liid,               // LIID
     }
 
     // Describes the IP packet.
-    transport.send_ip(liid, oper, cc_seq[liid]++, cin[liid],
+    transport.send_ip(tv, liid, oper, cc_seq[liid]++, cin[liid],
 		      pdu, country, net_elt, int_pt);
 
 
@@ -712,7 +721,7 @@ void connection::run()
 		ber::berpdu& time_p = hdr_p.get_element(5);
 		std::string tm;
 		time_p.decode_string(tm);
-		    
+
 		int Y, M, D, h, m, s, ms=0;
 		unsigned char gmt = 0;
 
@@ -741,7 +750,7 @@ void connection::run()
 
 		tv.tv_sec = timegm(&t);
 		tv.tv_usec = ms * 1000;  // Turn milliseconds into seconds.
-		
+
 	    } catch (...) {
 		// Time value defaults to 'now' if there's no timestamp in the
 		// data.
@@ -771,7 +780,7 @@ void connection::run()
 		it++) {
 
 		if (it->get_tag() == 1) {
-		  
+
 		    // CC case
 
 		    std::list<ber::berpdu> seq_pdus;
@@ -787,7 +796,7 @@ void connection::run()
 			ber::berpdu& packet_p = ipccontents_p.get_element(0);
 
 			std::vector<unsigned char> pkt;
-			
+
 			packet_p.decode_vector(pkt);
 
 			p(liid, network, pkt.begin(), pkt.end(), tv);
@@ -806,7 +815,7 @@ void connection::run()
 			std::list<ber::berpdu> seq_pdus;
 			it->decode_construct(seq_pdus);
 
-			for(std::list<ber::berpdu>::iterator it2 = 
+			for(std::list<ber::berpdu>::iterator it2 =
 				seq_pdus.begin();
 			    it2 != seq_pdus.end();
 			    it2++) {
@@ -817,10 +826,10 @@ void connection::run()
 			    ber::berpdu& iricontents_p = it2->get_element(2);
 			    ber::berpdu& ipiri_p = iricontents_p.get_element(2);
 
-			    ber::berpdu& ipiricontents_p = 
+			    ber::berpdu& ipiricontents_p =
 				ipiri_p.get_element(1);
 
-			    ber::berpdu& accesseventtype_p = 
+			    ber::berpdu& accesseventtype_p =
 				ipiricontents_p.get_element(0);
 
 			    accesseventtype = accesseventtype_p.decode_int();
@@ -828,15 +837,15 @@ void connection::run()
 			    // Get ready to decode IP address.
 			    try {
 
-				ber::berpdu& targetipaddress_p = 
+				ber::berpdu& targetipaddress_p =
 				    ipiricontents_p.get_element(4);
-				
-				ber::berpdu& ipvalue_p = 
+
+				ber::berpdu& ipvalue_p =
 				    targetipaddress_p.get_element(2);
-				
-				ber::berpdu& ipbinary_p = 
+
+				ber::berpdu& ipbinary_p =
 				    ipvalue_p.get_element(1);
-				
+
 				ipbinary_p.decode_vector(ip_addr);
 
 			    } catch (...) {
@@ -847,11 +856,11 @@ void connection::run()
 
 /*
 			    std::cerr << "IRI type = " << iritype << std::endl;
-			    std::cerr << "AET = " << accesseventtype 
+			    std::cerr << "AET = " << accesseventtype
 				      << std::endl;
 			    std::cerr << "Liid = " << liid << std::endl;;
-			    std::cerr << "Addr vec size = " 
-				      << ip_addr.size() 
+			    std::cerr << "Addr vec size = "
+				      << ip_addr.size()
 				      << std::endl;
 			    std::cerr << std::endl;
 */
@@ -866,7 +875,7 @@ void connection::run()
 						  ip_addr.end());
 				    p.target_up(liid, network, a, tv);
 				}
-			
+
 				if (ip_addr.size() == 16) {
 				    tcpip::ip6_address a;
 				    a.addr.assign(ip_addr.begin(),
@@ -875,7 +884,7 @@ void connection::run()
 				}
 
 			    }
-			    
+
 			    if (iritype == 2) {
 				p.target_down(liid, network, tv);
 			    }
@@ -892,7 +901,7 @@ void connection::run()
 	    }
 
 	}
-	
+
     } catch (std::exception& e) {
 	std::cerr << e.what() << std::endl;
     }

--- a/src/packet_consumer.h
+++ b/src/packet_consumer.h
@@ -2,12 +2,14 @@
 #ifndef PACKET_CONSUMER_H
 #define PACKET_CONSUMER_H
 
+#include <sys/time.h>
+
 class packet_consumer {
   public:
     virtual ~packet_consumer() {}
 
     // Allows caller to provide an IP packet for delivery.
-    virtual void receive_packet(const std::vector<unsigned char>& packet, 
+    virtual void receive_packet(timeval tv, const std::vector<unsigned char>& packet,
 				int datalink) = 0;
 
 };


### PR DESCRIPTION
These changes make cyberprobe use time from the PCAP pkthdr rather than 'now'.
This will make the timestamp slightly more accurate, and provides an interface by which time can be passed in.

Limitations/comments:
- only etsi_li supported, not nhsi11
- delay line packets will still take 'now' time
- target events (e.g. via CLI, or snort) that have no associated packet use 'now' time