### PR TITLE
remove copy on lua push for iterators

### DIFF
--- a/include/cybermon/cybermon-lua.h
+++ b/include/cybermon/cybermon-lua.h
@@ -206,13 +206,9 @@ namespace cybermon {
 	}
 
 	// Push a string (defined by iterators).
-	void push(std::vector<unsigned char>::const_iterator s,
-		  std::vector<unsigned char>::const_iterator e) {
-	    // FIXME: Lot of copying?
-	    unsigned char* buf = new unsigned char[e - s];
-	    std::copy(s, e, buf);
-	    lua_pushlstring(lua, (char*) buf, e - s);
-	    delete[] buf;
+	template < class Iter >
+	void push(Iter s, Iter e) {
+	    lua_pushlstring(lua, reinterpret_cast<const char*>(&(*s)), e - s);
 	}
 
 /*	void push(int size, unsigned char* buf ) {


### PR DESCRIPTION
(Also test push to upstream process)

change the lua push function for iterators to be: a. templatised, b. remove the unnecessary copy by using the underlying memory in the container as the string and let Lua handle the copy.

There will probably be a follow up change that will add type traits to the template