### PR TITLE
Fix Makefile.am depends

### DIFF
--- a/include/cybermon/event_protobuf.h
+++ b/include/cybermon/event_protobuf.h
@@ -2,7 +2,14 @@
 #ifndef CYBERMON_EVENT_PROTOBUF_H
 #define CYBERMON_EVENT_PROTOBUF_H
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#ifdef WITH_PROTOBUF
 #include "cyberprobe.pb.h"
+#endif
+
 #include <string>
 
 namespace cybermon {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -151,19 +151,24 @@ AM_CPPFLAGS += $(BOOST_CPPFLAGS) $(LUA_INCLUDE)
 AM_LDFLAGS += $(LDFLAGS_BOOST) $(LUA_LDADD)
 LIBS += $(LIBS_BOOST) $(LUA_LIB)
 
+BUILT_SOURCES =
+MOSTLYCLEANFILES =
+nodist_libcybermon_la_SOURCES =
+dist_noinst_DATA =
+
 if WITH_PROTOBUF
 
 cyberprobe.pb.cc cyberprobe.pb.h: ../protos/cyberprobe.proto
 	$(PROTOC) --proto_path=$(srcdir)/../protos --cpp_out=$(builddir) $^
 
-dist_noinst_DATA = ../protos/cyberprobe.proto
+dist_noinst_DATA += ../protos/cyberprobe.proto
 
-MOSTLYCLEANFILES = cyberprobe.pb.cc cyberprobe.pb.h
+MOSTLYCLEANFILES += cyberprobe.pb.cc cyberprobe.pb.h
 
-nodist_libcybermon_la_SOURCES = $(builddir)/cyberprobe.pb.cc \
+nodist_libcybermon_la_SOURCES += $(builddir)/cyberprobe.pb.cc \
 	$(builddir)/cyberprobe.pb.h
 
-BUILT_SOURCES=cyberprobe.pb.h
+BUILT_SOURCES += cyberprobe.pb.h
 
 if WITH_GRPC
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -152,6 +152,9 @@ AM_LDFLAGS += $(LDFLAGS_BOOST) $(LUA_LDADD)
 LIBS += $(LIBS_BOOST) $(LUA_LIB)
 
 BUILT_SOURCES =
+BUILT_SOURCES += cyberprobe.pb.h
+BUILT_SOURCES += cyberprobe.grpc.pb.h
+
 MOSTLYCLEANFILES =
 nodist_libcybermon_la_SOURCES =
 dist_noinst_DATA =
@@ -168,7 +171,6 @@ MOSTLYCLEANFILES += cyberprobe.pb.cc cyberprobe.pb.h
 nodist_libcybermon_la_SOURCES += $(builddir)/cyberprobe.pb.cc \
 	$(builddir)/cyberprobe.pb.h
 
-BUILT_SOURCES += cyberprobe.pb.h
 
 if WITH_GRPC
 
@@ -181,8 +183,6 @@ MOSTLYCLEANFILES += cyberprobe.grpc.pb.cc cyberprobe.grpc.pb.h
 
 nodist_libcybermon_la_SOURCES += $(builddir)/cyberprobe.grpc.pb.cc \
 	$(builddir)/cyberprobe.grpc.pb.h
-
-BUILT_SOURCES += cyberprobe.grpc.pb.h
 
 endif
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -156,6 +156,9 @@ BUILT_SOURCES += cyberprobe.pb.h
 BUILT_SOURCES += cyberprobe.grpc.pb.h
 
 MOSTLYCLEANFILES =
+MOSTLYCLEANFILES += cyberprobe.pb.cc cyberprobe.pb.h
+MOSTLYCLEANFILES += cyberprobe.grpc.pb.cc cyberprobe.grpc.pb.h
+
 nodist_libcybermon_la_SOURCES =
 dist_noinst_DATA =
 
@@ -165,8 +168,6 @@ cyberprobe.pb.cc cyberprobe.pb.h: ../protos/cyberprobe.proto
 	$(PROTOC) --proto_path=$(srcdir)/../protos --cpp_out=$(builddir) $^
 
 dist_noinst_DATA += ../protos/cyberprobe.proto
-
-MOSTLYCLEANFILES += cyberprobe.pb.cc cyberprobe.pb.h
 
 nodist_libcybermon_la_SOURCES += $(builddir)/cyberprobe.pb.cc \
 	$(builddir)/cyberprobe.pb.h
@@ -179,11 +180,19 @@ cyberprobe.grpc.pb.cc cyberprobe.grpc.pb.h: ../protos/cyberprobe.proto
 	    --grpc_out=$(builddir) \
 	    --plugin=protoc-gen-grpc=$$(which grpc_cpp_plugin) $<
 
-MOSTLYCLEANFILES += cyberprobe.grpc.pb.cc cyberprobe.grpc.pb.h
-
 nodist_libcybermon_la_SOURCES += $(builddir)/cyberprobe.grpc.pb.cc \
 	$(builddir)/cyberprobe.grpc.pb.h
 
+else 
+
+cyberprobe.grpc.pb.cc cyberprobe.grpc.pb.h:
+	touch $@
+
 endif
+
+else
+
+cyberprobe.pb.cc cyberprobe.pb.h:
+	touch $@
 
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -152,47 +152,31 @@ AM_LDFLAGS += $(LDFLAGS_BOOST) $(LUA_LDADD)
 LIBS += $(LIBS_BOOST) $(LUA_LIB)
 
 BUILT_SOURCES =
-BUILT_SOURCES += cyberprobe.pb.h
-BUILT_SOURCES += cyberprobe.grpc.pb.h
-
 MOSTLYCLEANFILES =
-MOSTLYCLEANFILES += cyberprobe.pb.cc cyberprobe.pb.h
-MOSTLYCLEANFILES += cyberprobe.grpc.pb.cc cyberprobe.grpc.pb.h
-
 nodist_libcybermon_la_SOURCES =
 dist_noinst_DATA =
 
 if WITH_PROTOBUF
 
 cyberprobe.pb.cc cyberprobe.pb.h: ../protos/cyberprobe.proto
-	$(PROTOC) --proto_path=$(srcdir)/../protos --cpp_out=$(builddir) $^
+	$(PROTOC) --proto_path=$(srcdir)/../protos --cpp_out=. $^
 
 dist_noinst_DATA += ../protos/cyberprobe.proto
-
-nodist_libcybermon_la_SOURCES += $(builddir)/cyberprobe.pb.cc \
-	$(builddir)/cyberprobe.pb.h
-
+nodist_libcybermon_la_SOURCES += cyberprobe.pb.cc cyberprobe.pb.h
+BUILT_SOURCES += cyberprobe.pb.h
+MOSTLYCLEANFILES += cyberprobe.pb.cc cyberprobe.pb.h
 
 if WITH_GRPC
 
 cyberprobe.grpc.pb.cc cyberprobe.grpc.pb.h: ../protos/cyberprobe.proto
 	$(PROTOC) --proto_path=$(srcdir)/../protos \
-	    --grpc_out=$(builddir) \
+	    --grpc_out=. \
 	    --plugin=protoc-gen-grpc=$$(which grpc_cpp_plugin) $<
 
-nodist_libcybermon_la_SOURCES += $(builddir)/cyberprobe.grpc.pb.cc \
-	$(builddir)/cyberprobe.grpc.pb.h
-
-else 
-
-cyberprobe.grpc.pb.cc cyberprobe.grpc.pb.h:
-	touch $@
+nodist_libcybermon_la_SOURCES += cyberprobe.grpc.pb.cc cyberprobe.grpc.pb.h
+MOSTLYCLEANFILES += cyberprobe.grpc.pb.cc cyberprobe.grpc.pb.h
+BUILT_SOURCES += cyberprobe.grpc.pb.h
 
 endif
-
-else
-
-cyberprobe.pb.cc cyberprobe.pb.h:
-	touch $@
 
 endif

--- a/src/decode_protobuf.C
+++ b/src/decode_protobuf.C
@@ -1,13 +1,23 @@
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <iostream>
 #include <iomanip>
 #include <memory>
 #include <string>
 
-#include <grpcpp/grpcpp.h>
+#ifdef WITH_PROTOBUF
 #include <google/protobuf/util/time_util.h>
 
+#ifdef WITH_GRPC
+#include <grpcpp/grpcpp.h>
 #include "cyberprobe.grpc.pb.h"
+#endif
+
+#endif
+
 #include <cybermon/socket.h>
 
 using grpc::Server;

--- a/src/event_protobuf.C
+++ b/src/event_protobuf.C
@@ -1,15 +1,21 @@
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <cybermon/event_implementations.h>
 #include <cybermon/event_protobuf.h>
 #include <cybermon/context.h>
 
+#ifdef WITH_PROTOBUF
 #include "cyberprobe.pb.h"
+#include <google/protobuf/util/time_util.h>
+#endif
 
 #include <string.h>
 #include <string>
 #include <cybermon/socket.h>
 
-#include <google/protobuf/util/time_util.h>
 
 // FIXME: All copied form event_json.C, should be a util class.
 


### PR DESCRIPTION
Something wrong with my Makefile.am in src...
```
Makefile:815: .deps/cyberprobe.grpc.pb.Plo: No such file or directory
Makefile:816: .deps/cyberprobe.pb.Plo: No such file or directory
make[3]: *** No rule to make target '.deps/cyberprobe.pb.Plo'.  Stop.
```
