### PR TITLE
Add -i INTERFACE option to cybermon to allow reading from interface

### DIFF
--- a/docs/ref-cybermon-invocation.texi
+++ b/docs/ref-cybermon-invocation.texi
@@ -14,8 +14,9 @@ provides.  Synposes:
 
 @example
 cybermon [--help] [--transport TRANSPORT] [--port PORT] [--key KEY]
-        [--certificate CERT] [--trusted-ca CHAIN] [--pcap PCAP_FILE]
-        [--config CONFIG] [--vxlan VXLAN-PORT]
+        [--certificate CERT] [--trusted-ca CHAIN] [--pcap PCAP-FILE]
+        [--config CONFIG] [--vxlan VXLAN-PORT] [--interface IFACE]
+        [--device DEVICE] [--time-limit LIMIT]
 @end example
 
 @itemize @bullet
@@ -45,7 +46,7 @@ Only used in TLS mode.
 specifies a filename for trusted CA keys in PEM format.  Only used in TLS mode.
 
 @item
-@var{PCAP_FILE}
+@var{PCAP-FILE}
 is a PCAP file to read.  This form of the command reads the PCAP file, and
 then exits.  If the file is @samp{-}, standard input is read.
 
@@ -60,5 +61,20 @@ should take when certain events are observed.  See
 is a UDP port number.  This describes a port number to listen on for
 VXLAN protocol.  This scenario is used to receive traffic-mirrored data
 on AWS.
+
+@item
+@var{IFACE}
+is a network interface to sniff for packets as input.
+
+@item
+@var{DEVICE}
+is a device-name to include in the output events.  Use this to specify
+the device for PCAP files, interfaces or VXLAN input if you don't want the
+default placeholder.
+
+@item
+@var{LIMIT}
+is the length of time to run for (in seconds).  The program exits after this
+period.
 
 @end itemize

--- a/src/capture.C
+++ b/src/capture.C
@@ -55,7 +55,7 @@ void pcap_dev::run()
 	    throw std::runtime_error("poll failed");
 
 	if (pfd.revents)
-            pcap_dispatch(p, 1, handler, (unsigned char *) this);
+            pcap_dispatch(p, 1, handle_packet, (unsigned char *) this);
 
         service_delayline();
 

--- a/src/capture.h
+++ b/src/capture.h
@@ -23,6 +23,8 @@ public:
 
 };
 
+using packet_handler = cybermon::pcap::packet_handler;
+
 class delayline_dev : public capture_dev {
 protected:
 
@@ -160,7 +162,9 @@ public:
 
 // Packet capture.  Captures on an interface, and then submits captured
 // packets to the delivery engine.
-class pcap_dev : public cybermon::pcap::interface , public delayline_dev {
+class pcap_dev : public cybermon::pcap::interface ,
+                 public packet_handler,
+                 public delayline_dev {
 private:
 
     std::thread* thr;
@@ -172,7 +176,7 @@ public:
 
     // Constructor.  i=interface name, d=packet consumer.
     pcap_dev(const std::string& i, float delay, packet_consumer& d) :
-	interface(i), delayline_dev(d, delay, pcap_datalink(p)) {
+	interface(*this, i), delayline_dev(d, delay, pcap_datalink(p)) {
 	thr = 0;
     }
 

--- a/src/capture.h
+++ b/src/capture.h
@@ -160,7 +160,7 @@ public:
 
 // Packet capture.  Captures on an interface, and then submits captured
 // packets to the delivery engine.
-class pcap_dev : public pcap_interface , public delayline_dev {
+class pcap_dev : public cybermon::pcap::interface , public delayline_dev {
 private:
 
     std::thread* thr;
@@ -172,7 +172,7 @@ public:
 
     // Constructor.  i=interface name, d=packet consumer.
     pcap_dev(const std::string& i, float delay, packet_consumer& d) :
-	pcap_interface(i), delayline_dev(d, delay, pcap_datalink(p)) {
+	interface(i), delayline_dev(d, delay, pcap_datalink(p)) {
 	thr = 0;
     }
 
@@ -182,7 +182,7 @@ public:
     }
 
     virtual void stop() {
-	pcap_interface::stop();
+	interface::stop();
 	running = false;
     }
 

--- a/src/cybermon.C
+++ b/src/cybermon.C
@@ -105,7 +105,8 @@ public:
 
 };
 
-class pcap_input : public cybermon::pcap::reader {
+class pcap_input : public cybermon::pcap::reader,
+                   public cybermon::pcap::packet_handler {
 private:
     cybermon::engine& e;
     int count;
@@ -116,7 +117,7 @@ private:
 public:
     pcap_input(const std::string& f, cybermon::engine& e,
                const std::string& device) :
-	cybermon::pcap::reader(f), e(e), device(device) {
+	cybermon::pcap::reader(*this, f), e(e), device(device) {
 	count = 0;
     }
 

--- a/src/cybermon.C
+++ b/src/cybermon.C
@@ -105,7 +105,7 @@ public:
 
 };
 
-class pcap_input : public pcap_reader {
+class pcap_input : public cybermon::pcap::reader {
 private:
     cybermon::engine& e;
     int count;
@@ -116,12 +116,12 @@ private:
 public:
     pcap_input(const std::string& f, cybermon::engine& e,
                const std::string& device) :
-	pcap_reader(f), e(e), device(device) {
+	cybermon::pcap::reader(f), e(e), device(device) {
 	count = 0;
     }
 
     virtual void stop() {
-	pcap_reader::stop();
+	reader::stop();
     }
 
     virtual void join() {

--- a/src/etsi_rcvr.C
+++ b/src/etsi_rcvr.C
@@ -13,10 +13,10 @@ ETSI LI test receiver.  Usage:
 
 class output : public cybermon::monitor {
 private:
-    pcap_writer& p;
+    cybermon::pcap::writer& p;
     std::mutex mutex;
 public:
-    output(pcap_writer& p) : p(p) {}
+    output(cybermon::pcap::writer& p) : p(p) {}
     virtual void operator()(const std::string& liid,
 			    const std::string& network,
                             cybermon::pdu_slice s) {
@@ -55,7 +55,7 @@ int main(int argc, char** argv)
 	int port;
 	buf >> port;
 
-	pcap_writer p;
+        cybermon::pcap::writer p;
 
 	output o(p);
 

--- a/src/nhis11_rcvr.C
+++ b/src/nhis11_rcvr.C
@@ -19,10 +19,10 @@ NHIS 1.1 test receiver.  Usage:
 
 class output : public cybermon::monitor {
 private:
-    pcap_writer& p;
+    cybermon::pcap::writer& p;
     std::mutex mutex;
 public:
-    output(pcap_writer& p) : p(p) {}
+    output(cybermon::pcap::writer& p) : p(p) {}
     virtual void operator()(const std::string& liid,
 			    const std::string& network,
                             cybermon::pdu_slice s) {
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
 	int port;
 	buf >> port;
 
-	pcap_writer p;
+        cybermon::pcap::writer p;
 
 	output o(p);
 


### PR DESCRIPTION
Add -i INTERFACE option to cybermon to allow reading from interface.  This provides a simpler means of reading from a network interface without using the cyberprobe component when you don't need to use device tagging, dynamic operation or delay line.

Also, refactor the PCAP stuff for a slightly tidier implementation.
