### PR TITLE
Fix high latency packet capture in F30

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,9 @@ AC_CHECK_LIB([pcap], [main], [], [AC_MSG_ERROR(Library pcap missing.)])
 AC_SEARCH_LIBS([pcap_create], [pcap],
 		    [AC_DEFINE([HAVE_PCAP_CREATE], 1,
 		    [Set if pcap_create is supported (added in libpcap 1.0)])])
+AC_SEARCH_LIBS([pcap_set_timeout], [pcap],
+		    [AC_DEFINE([HAVE_PCAP_SET_TIMEOUT], 1,
+		    [Set if pcap_set_timeout is supported])])
 AC_CHECK_LIB([pthread], [main], [], [AC_MSG_ERROR(Library pthread missing.)])
 AC_CHECK_LIB([readline], [main], [], [AC_MSG_ERROR(Library readline missing.)])
 AC_CHECK_LIB([ssl], [main], [], [AC_MSG_ERROR(Library ssl missing.)])

--- a/include/cyberprobe/pkt_capture/packet_capture.h
+++ b/include/cyberprobe/pkt_capture/packet_capture.h
@@ -156,7 +156,9 @@ public:
                 pcap_set_rfmon(p, 1);
             pcap_set_promisc(p, 1);
 
+#ifdef HAVE_PCAP_SET_TIMEOUT
             pcap_set_timeout(p, 1);
+#endif
             
             int ret = pcap_activate(p);
             if (ret < 0) {

--- a/include/cyberprobe/pkt_capture/packet_capture.h
+++ b/include/cyberprobe/pkt_capture/packet_capture.h
@@ -155,6 +155,8 @@ public:
             if (pcap_can_set_rfmon(p))
                 pcap_set_rfmon(p, 1);
             pcap_set_promisc(p, 1);
+
+            pcap_set_timeout(p, 1);
             
             int ret = pcap_activate(p);
             if (ret < 0) {


### PR DESCRIPTION
Added pcap_set_timeout to set timeout to 1.   Need to get packet capture to work without high latency on Fed 30.  Guess something changed in PCAP API?
