### PR TITLE
Fix build errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,10 +120,10 @@ AC_CHECK_LIB([dag], [main],
 AC_SEARCH_LIBS([luaL_register], [lua lua5.1],
 		    [AC_DEFINE([HAVE_LUAL_REGISTER], 1,
 		    [Set if luaL_register is supported (removed in 5.2)])])
-AC_SEARCH_LIBS([luaL_setfuncs], [lua lua5.2],
+AC_SEARCH_LIBS([luaL_setfuncs], [lua lua5.2 lua5.3 lua5.4 lua5.5 lua5.6],
 		    [AC_DEFINE([HAVE_LUAL_SETFUNCS], 1,
 		    [Set if luaL_setfuncs is supported (added in 5.2)])])
-AC_SEARCH_LIBS([lua_rawlen], [lua lua5.2],
+AC_SEARCH_LIBS([lua_rawlen], [lua lua5.2 lua5.3 lua5.4 lua5.5 lua5.6],
 		    [AC_DEFINE([HAVE_LUA_RAWLEN], 1,
 		    [Set if lua_rawlen is supported (added in 5.2)])])
 

--- a/include/cyberprobe/protocol/tls_utils.h
+++ b/include/cyberprobe/protocol/tls_utils.h
@@ -3,6 +3,7 @@
 #define TLS_UTILS_H
 
 #include <string>
+#include <stdint.h>
 
 namespace cyberprobe {
     namespace protocol {

--- a/include/cyberprobe/util/hardware_addr_utils.h
+++ b/include/cyberprobe/util/hardware_addr_utils.h
@@ -3,6 +3,7 @@
 #define HARDWARE_ADDR_UTILS_H
 
 #include <string>
+#include <stdint.h>
 
 namespace cyberprobe {
     namespace util {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,7 +49,7 @@ cybermon_LDADD = libcybermon.la -lssl
 
 if WITH_PROTOBUF
 if WITH_GRPC
-cybermon_LDADD += -lgrpc++ -lgrpc
+cybermon_LDADD += -lgrpc++ -lgrpc -lgpr
 endif
 cybermon_LDADD += -lprotobuf
 endif
@@ -183,7 +183,8 @@ libcybermon_la_SOURCES += analyser/grpc.C ../include/cyberprobe/analyser/grpc.h
 
 eventstream_service_SOURCES = eventstream-service.C network/socket.C	\
 	../include/cyberprobe/network/socket.h
-eventstream_service_LDADD = libcybermon.la -lssl -lgrpc++ -lgrpc -lprotobuf
+eventstream_service_LDADD = libcybermon.la -lssl -lgrpc++ -lgrpc -lgpr \
+	-lprotobuf
 
 endif
 endif

--- a/src/protocol/tls_utils.C
+++ b/src/protocol/tls_utils.C
@@ -2,6 +2,8 @@
 #include <cyberprobe/protocol/tls_utils.h>
 #include <cyberprobe/protocol/tls_exception.h>
 
+#include <stdint.h>
+
 using namespace cyberprobe::protocol;
 
 std::string tls_utils::convertTLSVersion(uint8_t maj, uint8_t min)

--- a/src/util/hardware_addr_utils.C
+++ b/src/util/hardware_addr_utils.C
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <iomanip>
 #include <sstream>
+#include <stdint.h>
 
 using namespace cyberprobe::util;
 


### PR DESCRIPTION
Build hasn't been tested recently, this addresses errors errors in:
- Lua since 5.4 release
- Linkage to stdint.h definitions
- Linkage to gRPC libraries
- 